### PR TITLE
Custom initial weights parser

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ set(SOURCES
     src/InitialWeights/randomnormal.cpp
     src/InitialWeights/automatize.cpp
     src/InitialWeights/javier.cpp
+    src/InitialWeights/fromfile.cpp
     src/InitialWeights/customized.cpp
     src/Interaction/interaction.cpp
     src/Interaction/nointeraction.cpp

--- a/src/InitialWeights/automatize.cpp
+++ b/src/InitialWeights/automatize.cpp
@@ -1,5 +1,6 @@
 #include <fstream>
 #include <memory>
+#include <Eigen/Dense>
 
 #include "automatize.h"
 #include "../Optimization/optimization.h"
@@ -84,9 +85,9 @@ void Automatize::setupInitialWeights()
     } else if (m_trialWaveFunction == "RBM") {
         m_method = std::make_unique<Javier> (m_system);
     } else if (m_trialWaveFunction == "RBMSJ") {
-        m_method = std::make_unique<RandomUniformWeights> (m_system, 0.2);
+        m_method = std::make_unique<Javier> (m_system);
     } else if (m_trialWaveFunction == "RBMPJ") {
-        m_method = std::make_unique<Constant> (m_system, 0.0);
+        m_method = std::make_unique<Javier> (m_system);
     } else if (m_trialWaveFunction == "PRBM") {
         m_method = std::make_unique<Constant> (m_system, 0.0);
     } else if (m_trialWaveFunction == "SSJ") {

--- a/src/InitialWeights/fromfile.cpp
+++ b/src/InitialWeights/fromfile.cpp
@@ -1,0 +1,84 @@
+#include <iostream>
+#include <fstream>
+#include <Eigen/Dense>
+#include <string>
+#include <cassert>
+
+#include "fromfile.h"
+#include "../system.h"
+
+#define MAXBUFSIZE  ((int) 1e6)
+
+
+/* ----------------------------------------------------------------------------
+  Initialize weights from file class constructor
+---------------------------------------------------------------------------- */
+
+FromFile::FromFile(System *system, std::string filename)
+    : InitialWeights(system)
+{
+    m_system = system;
+    m_filename = filename;
+}
+
+
+/* ----------------------------------------------------------------------------
+  Setup initial weights after number of elements and max number of parameters
+  are found
+---------------------------------------------------------------------------- */
+
+void FromFile::setupInitialWeights()
+{
+    int cols = 0, rows = 0;
+    double buff[MAXBUFSIZE];
+
+    m_numberOfElements = m_system->getNumberOfElements();
+    m_maxParameters = m_system->getMaxParameters();
+    m_parameters = Eigen::MatrixXd::Zero(m_numberOfElements, m_maxParameters);
+
+    // Read numbers from file into buffer.
+    std::ifstream infile;
+    infile.open(m_filename);
+    while (! infile.eof())
+        {
+        std::string line;
+        std::getline(infile, line);
+
+        int temp_cols = 0;
+        std::stringstream stream(line);
+        while(! stream.eof())
+            stream >> buff[cols*rows+temp_cols++];
+
+        if (temp_cols == 0)
+            continue;
+
+        if (cols == 0)
+            cols = temp_cols;
+
+        rows++;
+        }
+
+    infile.close();
+
+    rows--;
+
+    assert (rows == m_numberOfElements);
+    assert (cols == m_maxParameters);
+
+    // Populate matrix with numbers.
+    for (int i = 0; i < rows; i++)
+        for (int j = 0; j < cols; j++)
+            m_parameters(i,j) = buff[ cols*i+j ];
+
+    m_system->updateAllParameters(m_parameters);
+}
+
+
+/* ----------------------------------------------------------------------------
+  Get parameters from class. Parameters are declared private
+---------------------------------------------------------------------------- */
+
+Eigen::MatrixXd FromFile::getParameters()
+{
+    return m_parameters;
+}

--- a/src/InitialWeights/fromfile.h
+++ b/src/InitialWeights/fromfile.h
@@ -1,0 +1,19 @@
+#pragma once
+#include <string>
+
+#include "initialweights.h"
+
+class FromFile : public InitialWeights
+{
+public:
+    FromFile(System *system, std::string = "weights.dat");
+    std::string getLabel() { return m_label; }
+    void setupInitialWeights();
+
+    Eigen::MatrixXd getParameters();
+
+private:
+    double m_factor = 1;
+    std::string m_filename;
+    std::string m_label = "from-file";
+};

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -177,6 +177,12 @@ void System::parser(const std::string configFile)
                             } else {
                                 setInitialWeights(new Constant(this, 1.0));
                             }
+                        } else if (splitted.at(0) == "fromfile") {
+                            if (splitted.size() >= 2) {
+                                setInitialWeights(new FromFile(this, splitted.at(1)));
+                            } else {
+                                setInitialWeights(new FromFile(this));
+                            }
                         } else {
                             std::cout << std::endl;
                             std::cerr << "Initial parameter configuration '"


### PR DESCRIPTION
Trial wave function parameters (weights) can now be initialised from file. By writing out the parameters after a run, the training can easily start from the previous state